### PR TITLE
enable the possibility for denss.fit_data.py to read RAW .dat files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+build/

--- a/bin/denss.fit_data.py
+++ b/bin/denss.fit_data.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
     else:
         output = args.output
 
-    Iq = np.loadtxt(args.file)
+    Iq = np.genfromtxt(args.file, invalid_raise = False)
+    Iq = Iq[~np.isnan(Iq).any(axis = 1)]
     D = args.dmax
     nes = args.nes
 
@@ -97,7 +98,7 @@ if __name__ == "__main__":
     if args.plot:
         import matplotlib.pyplot as plt
         from matplotlib.widgets import Slider, Button, RadioButtons
-        
+
         #fig, (axI, axP) = plt.subplots(1, 2, figsize=(12,6))
         fig = plt.figure(0, figsize=(12,6))
         axI = plt.subplot2grid((3,2), (0,0),rowspan=2)
@@ -220,15 +221,3 @@ if __name__ == "__main__":
 
     np.savetxt(output+'.dat', np.vstack((sasrec.qc, sasrec.Ic, Icerr)).T,delimiter=' ',fmt='%.5e')
     print "%s file saved" % (output+".dat")
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
denss.fit_data.py was returning a string to float conversion error for .dat files containing a header before and after the numerical values. 

```bash
$ denss.fit_data.py -f S_A_02492_A1_MerB3_063_c.dat 
/home/sbio/norm/softwares/denss/venv/local/lib/python2.7/site-packages/saxstats/saxstats.pyc
Traceback (most recent call last):
  File "/home/sbio/norm/softwares/denss/venv/bin/denss.fit_data.py", line 73, in <module>
    Iq = np.loadtxt(args.file)
  File "/home/sbio/norm/softwares/denss/venv/local/lib/python2.7/site-packages/numpy/lib/npyio.py", line 1134, in loadtxt
    for x in read_data(_loadtxt_chunksize):
  File "/home/sbio/norm/softwares/denss/venv/local/lib/python2.7/site-packages/numpy/lib/npyio.py", line 1061, in read_data
    items = [conv(val) for (conv, val) in zip(converters, vals)]
  File "/home/sbio/norm/softwares/denss/venv/local/lib/python2.7/site-packages/numpy/lib/npyio.py", line 768, in floatconv
    return float(x)
ValueError: could not convert string to float: Q
```

These headers are found in .dat files generated by RAW (using v.1.5.1 in my case) where column names are specified above the data, and additional information is provided after the data with respect to analysis performed in RAW.

Using `numpy.genfromtxt` instead of `numpy.loadtxt` solved the problem. `NaN` values were however created and needed some extra code to remove them.