### PR TITLE
Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 numpy
 scipy
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 exec(compile(open('saxstats/_version.py').read(), 'saxstats/_version.py', 'exec'))
 


### PR DESCRIPTION
This is simple patch to allow the build of **wheel** packages with `python setup.py bdist_wheel` 